### PR TITLE
Update setup.py from sklearn to scikit-learn

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
   name = "Dora",
-  version = "0.0.3",
+  version = "0.0.4",
   author = "Nathan Epstein",
   author_email = "ne2210@columbia.edu",
   description = ("Exploratory data analysis toolkit for Python"),
@@ -13,7 +13,7 @@ setup(
     "pandas>=0.17.1",
     "numpy>=1.10.4",
     "scipy>=0.17.0",
-    "sklearn",
+    "scikit-learn",
   ],
   packages = ['Dora']
 )


### PR DESCRIPTION
When attempting to install `Dora`, we observe the following error:

```
$ pip3 --version
pip 23.3.2 from /home/vtjeng/.local/lib/python3.8/site-packages/pip (python 3.8)

$ pip3 install Dora
Defaulting to user installation because normal site-packages is not writeable
Collecting Dora
  Using cached Dora-0.0.3.tar.gz (4.9 kB)
  Preparing metadata (setup.py) ... done
Requirement already satisfied: matplotlib>=1.5.1 in /home/vtjeng/.local/lib/python3.8/site-packages (from Dora) (3.1.3)
Requirement already satisfied: numpy>=1.10.4 in /home/vtjeng/.local/lib/python3.8/site-packages (from Dora) (1.18.5)
Requirement already satisfied: pandas>=0.17.1 in /home/vtjeng/.local/lib/python3.8/site-packages (from Dora) (1.2.3)
Requirement already satisfied: scipy>=0.17.0 in /home/vtjeng/.local/lib/python3.8/site-packages (from Dora) (1.4.1)
Collecting sklearn (from Dora)
  Using cached sklearn-0.0.post12.tar.gz (2.6 kB)
  Preparing metadata (setup.py) ... error
  error: subprocess-exited-with-error

  × python setup.py egg_info did not run successfully.
  │ exit code: 1
  ╰─> [15 lines of output]
      The 'sklearn' PyPI package is deprecated, use 'scikit-learn'
      rather than 'sklearn' for pip commands.

      Here is how to fix this error in the main use cases:
      - use 'pip install scikit-learn' rather than 'pip install sklearn'
      - replace 'sklearn' by 'scikit-learn' in your pip requirements files
        (requirements.txt, setup.py, setup.cfg, Pipfile, etc ...)
      - if the 'sklearn' package is used by one of your dependencies,
        it would be great if you take some time to track which package uses
        'sklearn' instead of 'scikit-learn' and report it to their issue tracker
      - as a last resort, set the environment variable
        SKLEARN_ALLOW_DEPRECATED_SKLEARN_PACKAGE_INSTALL=True to avoid this error

      More information is available at
      https://github.com/scikit-learn/sklearn-pypi-package
      [end of output]

  note: This error originates from a subprocess, and is likely not a problem with pip.
error: metadata-generation-failed

× Encountered error while generating package metadata.
```